### PR TITLE
Disable waiting until video has finished buffering before enabling the "Start training" / "Start predictions" buttons

### DIFF
--- a/src/apps/client/src/electron/main.js
+++ b/src/apps/client/src/electron/main.js
@@ -78,7 +78,7 @@ subscribeKey(ctx, "serversLoaded", (v) => {
     y: 0 + 96 / 2 + 72 / 2 + 10,
   });
   overlayView.webContents.loadURL(
-    clientURL.replace("0.0.0.0", "localhost") + "/overlay"
+    clientURL.replace("0.0.0.0", "localhost") + "/overlay",
   ); // overlay loads at http://localhost:8001/overlay by default
   overlayView.setVisible(false); // hide the overlay view until needed
   // overlayView.webContents.openDevTools({ mode: "detach" }); // uncomment to open devtools in separate window on start
@@ -91,7 +91,7 @@ subscribeKey(ctx, "serversLoaded", (v) => {
 
 // electron - general window events
 app.on("window-all-closed", () =>
-  process.platform !== "darwin" ? app.quit() : null
+  process.platform !== "darwin" ? app.quit() : null,
 );
 app.on("activate", () => (win === null ? createWindow() : null));
 
@@ -110,9 +110,9 @@ ipcMain.on("toMain", (event, payload) => {
     case "req:load-overlay":
       loadOverlay(event, payload);
       break;
-    case "info:video-playing":
-      informVideoPlaying(event, payload);
-      break;
+    // case "info:video-playing":
+    //   informVideoPlaying(event, payload);
+    //   break;
     default:
       sio.emit(id, data);
       event.sender.send("fromMain", {
@@ -172,10 +172,10 @@ const unloadSocialMedia = (event, payload) => {
     win.contentView.removeChildView(smView);
     smView = null;
     overlayView.setVisible(false);
-    informVideoPlaying(event, {
-      id: "info:video-playing",
-      data: { value: false },
-    });
+    // informVideoPlaying(event, {
+    //   id: "info:video-playing",
+    //   data: { value: false },
+    // });
   }
 };
 
@@ -194,10 +194,10 @@ const loadOverlay = (event, payload) => {
   }
 };
 
-const informVideoPlaying = (event, payload) => {
-  const { id, data } = payload;
-  win.webContents.send("fromMain", {
-    id: "info:video-playing",
-    data: { value: data.value },
-  });
-};
+// const informVideoPlaying = (event, payload) => {
+//   const { id, data } = payload;
+//   win.webContents.send("fromMain", {
+//     id: "info:video-playing",
+//     data: { value: data.value },
+//   });
+// };

--- a/src/apps/client/src/electron/preloadExternal.js
+++ b/src/apps/client/src/electron/preloadExternal.js
@@ -100,10 +100,10 @@ window.onload = () => {
   getCurrentReelAsync().then(() => {
     window.scrollTo(0, 0);
     document.body.scrollIntoView();
-    ipcRenderer.send("toMain", {
-      id: "info:video-playing",
-      data: { value: true },
-    });
+    // ipcRenderer.send("toMain", {
+    //   id: "info:video-playing",
+    //   data: { value: true },
+    // });
   });
 
   ipcRenderer.on("fromMain", async (event, payload) => {

--- a/src/apps/client/src/stores/global.store.js
+++ b/src/apps/client/src/stores/global.store.js
@@ -31,7 +31,8 @@ let globalStore = proxy({
   },
   ui: {
     videoState: {
-      isPlaying: false,
+      // isPlaying: false,
+      isPlaying: true,
     },
 
     trainingBtn: {
@@ -181,7 +182,7 @@ globalStore.__fns.initialize = () => {
   }
   if (localStorage.getItem("selected-settings")) {
     globalStore.settings.selected = JSON.parse(
-      localStorage.getItem("selected-settings")
+      localStorage.getItem("selected-settings"),
     );
   }
 };
@@ -196,7 +197,7 @@ globalStore.__fns.subscribe((v) => {
   if (["settings", "selected"].some((k) => v[0][1].includes(k))) {
     localStorage.setItem(
       "selected-settings",
-      JSON.stringify(globalStore.settings.selected)
+      JSON.stringify(globalStore.settings.selected),
     );
   }
 });
@@ -224,9 +225,9 @@ if (window.api) {
       case "py:action-detected":
         globalStore.ui.predictionState.state = "actionDetected";
         break;
-      case "info:video-playing":
-        globalStore.ui.videoState.isPlaying = data.value;
-        break;
+      // case "info:video-playing":
+      //   globalStore.ui.videoState.isPlaying = data.value;
+      //   break;
     }
   });
 }


### PR DESCRIPTION
Still unsure why the loading of Instagram reels appears to be throttled when testing on Morpheus, but I have temporarily commented out the relevant front-end logic to avoid the long delay caused by video buffering. This ensures the "start training" and "start predictions" buttons remain enabled regardless of the video's status.